### PR TITLE
Refactor pop_end_marker() and get_block_len()

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -516,20 +516,14 @@ fn make_prefix_free(records: &mut [Record]) -> Result<()> {
 }
 
 fn pop_end_marker(x: &[char]) -> Vec<char> {
-    let mut x = x.to_vec();
-    if let Some(&c) = x.last() {
-        if c == END_MARKER {
-            x.pop();
-        }
+    match x.split_last() {
+        Some((&END_MARKER, elems)) => elems.to_vec(),
+        _ => x.to_vec(),
     }
-    x
 }
 
 const fn get_block_len(alphabet_size: u32) -> u32 {
     let max_code = alphabet_size - 1;
-    let mut shift = 1;
-    while (max_code >> shift) != 0 {
-        shift += 1;
-    }
+    let shift = 32 - max_code.leading_zeros();
     1 << shift
 }


### PR DESCRIPTION
This branch refactors `pop_end_marker()` and `get_block_len()` functions.

The previous `pop_end_marker()` checks the last element and calls `.pop()`.
In this case, the function always allocates an additional unused area.
In contrast, this branch uses `.split_last()` to expect the minimum necessary areas are allocated. (Note: This is not guaranteed.)

Although `get_block_len()` is called only once, using `leading_zeros()` is simpler and more efficient than using a while loop.
The previous code uses jumps and shifts while `leading_zeros()` uses the Bit Scan Reverse (bsr) operation.
<img width="1434" alt="Screenshot 2022-04-02 at 21 53 25" src="https://user-images.githubusercontent.com/2175479/161385947-9a79b5da-e388-4f71-8751-3ee20158f3d5.png">
(In this screenshot, two Rust versions are different, but it does not affect the result.)
