### PR TITLE
Add skipping approach for faster construction

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -7,6 +7,7 @@ use core::cmp::Ordering;
 
 use alloc::vec::Vec;
 
+// The default parameter for free blocks to be searched in `find_base`.
 const DEFAULT_NUM_FREE_BLOCKS: u32 = 16;
 
 #[derive(Default)]
@@ -419,7 +420,10 @@ impl Builder {
             // Here, self.head_idx != INVALID_IDX is ensured,
             // because INVALID_IDX is the maximum value in u32.
             debug_assert_ne!(self.head_idx, INVALID_IDX);
-            self.fix_node(self.head_idx);
+            let idx = self.head_idx;
+            self.fix_node(idx);
+            self.node_mut(idx).base = OFFSET_MASK;
+            self.node_mut(idx).check = OFFSET_MASK;
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -77,7 +77,7 @@ impl Builder {
 
         make_prefix_free(&mut self.records)?;
 
-        self.block_len = get_block_len(self.mapper.alphabet_size());
+        self.block_len = self.mapper.alphabet_size().next_power_of_two().max(2);
         self.init_array();
         self.arrange_nodes(0, self.records.len(), 0, 0)?;
         self.finish();
@@ -497,10 +497,4 @@ fn pop_end_marker(x: &[char]) -> Vec<char> {
         Some((&END_MARKER, elems)) => elems.to_vec(),
         _ => x.to_vec(),
     }
-}
-
-const fn get_block_len(alphabet_size: u32) -> u32 {
-    let max_code = alphabet_size - 1;
-    let shift = 32 - max_code.leading_zeros();
-    1 << shift
 }


### PR DESCRIPTION
This PR implemented a skipping approach for faster construction.

On UniDic, the construction times were improved from

```
[crawdad/trie]
heap_bytes: 9795880 bytes, 9.342 MiB
num_elems: 1138688
num_vacants: 119677
vacant_ratio: 0.105
construction: 7.125 [sec]
[crawdad/mptrie]
heap_bytes: 11500152 bytes, 10.967 MiB
num_elems: 1024000
num_vacants: 180321
vacant_ratio: 0.176
construction: 15.686 [sec]
```

to

```
[crawdad/trie]
heap_bytes: 9861416 bytes, 9.405 MiB
num_elems: 1146880
num_vacants: 127869
vacant_ratio: 0.111
construction: 3.333 [sec]
[crawdad/mptrie]
heap_bytes: 11500152 bytes, 10.967 MiB
num_elems: 1024000
num_vacants: 180321
vacant_ratio: 0.176
construction: 4.526 [sec]
```

In this version, I do not add functions to set `Builder::num_free_blocks` because of avoiding to complicate the API.
(i.e., num_free_blocks is always fixed with 16)