### PR TITLE
Simplify and speed up common prefix searcher

### DIFF
--- a/bench/benches/search.rs
+++ b/bench/benches/search.rs
@@ -153,7 +153,7 @@ fn add_enumerate_benches(group: &mut BenchmarkGroup<WallTime>, keys: &[String], 
                 haystack.clear();
                 haystack.extend(text.chars());
                 for i in 0..haystack.len() {
-                    for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                    for (v, j) in trie.common_prefix_search(haystack[i..].iter().copied()) {
                         dummy += j + v as usize;
                     }
                 }

--- a/bench/benches/search.rs
+++ b/bench/benches/search.rs
@@ -146,14 +146,15 @@ fn add_exact_match_benches(
 fn add_enumerate_benches(group: &mut BenchmarkGroup<WallTime>, keys: &[String], texts: &[String]) {
     group.bench_function("crawdad/trie", |b| {
         let trie = crawdad::Trie::from_keys(keys).unwrap();
-        let mut searcher = trie.common_prefix_searcher();
+        let mut haystack = Vec::with_capacity(256);
         b.iter(|| {
             let mut dummy = 0;
             for text in texts {
-                searcher.update_haystack(text.chars());
-                for i in 0..searcher.len_chars() {
-                    for m in searcher.search(i) {
-                        dummy += m.end_bytes() + m.value() as usize;
+                haystack.clear();
+                text.chars().for_each(|c| haystack.push(c));
+                for i in 0..haystack.len() {
+                    for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                        dummy += j + v as usize;
                     }
                 }
             }

--- a/bench/benches/search.rs
+++ b/bench/benches/search.rs
@@ -173,7 +173,7 @@ fn add_enumerate_benches(group: &mut BenchmarkGroup<WallTime>, keys: &[String], 
                 haystack.clear();
                 haystack.extend(text.chars());
                 for i in 0..haystack.len() {
-                    for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                    for (v, j) in trie.common_prefix_search(haystack[i..].iter().copied()) {
                         dummy += j + v as usize;
                     }
                 }

--- a/bench/benches/search.rs
+++ b/bench/benches/search.rs
@@ -166,14 +166,15 @@ fn add_enumerate_benches(group: &mut BenchmarkGroup<WallTime>, keys: &[String], 
 
     group.bench_function("crawdad/mptrie", |b| {
         let trie = crawdad::MpTrie::from_keys(keys).unwrap();
-        let mut searcher = trie.common_prefix_searcher();
+        let mut haystack = Vec::with_capacity(256);
         b.iter(|| {
             let mut dummy = 0;
             for text in texts {
-                searcher.update_haystack(text.chars());
-                for i in 0..searcher.len_chars() {
-                    for m in searcher.search(i) {
-                        dummy += m.end_bytes() + m.value() as usize;
+                haystack.clear();
+                text.chars().for_each(|c| haystack.push(c));
+                for i in 0..haystack.len() {
+                    for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                        dummy += j + v as usize;
                     }
                 }
             }

--- a/bench/benches/search.rs
+++ b/bench/benches/search.rs
@@ -146,12 +146,12 @@ fn add_exact_match_benches(
 fn add_enumerate_benches(group: &mut BenchmarkGroup<WallTime>, keys: &[String], texts: &[String]) {
     group.bench_function("crawdad/trie", |b| {
         let trie = crawdad::Trie::from_keys(keys).unwrap();
-        let mut haystack = Vec::with_capacity(256);
+        let mut haystack = vec![];
         b.iter(|| {
             let mut dummy = 0;
             for text in texts {
                 haystack.clear();
-                text.chars().for_each(|c| haystack.push(c));
+                haystack.extend(text.chars());
                 for i in 0..haystack.len() {
                     for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
                         dummy += j + v as usize;
@@ -166,12 +166,12 @@ fn add_enumerate_benches(group: &mut BenchmarkGroup<WallTime>, keys: &[String], 
 
     group.bench_function("crawdad/mptrie", |b| {
         let trie = crawdad::MpTrie::from_keys(keys).unwrap();
-        let mut haystack = Vec::with_capacity(256);
+        let mut haystack = vec![];
         b.iter(|| {
             let mut dummy = 0;
             for text in texts {
                 haystack.clear();
-                text.chars().for_each(|c| haystack.push(c));
+                haystack.extend(text.chars());
                 for i in 0..haystack.len() {
                     for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
                         dummy += j + v as usize;

--- a/bench/src/measure.rs
+++ b/bench/src/measure.rs
@@ -68,13 +68,14 @@ fn main() {
         if let Some(texts) = texts.as_ref() {
             // Warmup
             let mut dummy = 0;
-            let mut searcher = trie.common_prefix_searcher();
+            let mut haystack = vec![];
             let elapsed_sec = measure(TRIALS, || {
                 for text in texts {
-                    searcher.update_haystack(text.chars());
-                    for i in 0..searcher.len_chars() {
-                        for m in searcher.search(i) {
-                            dummy += m.end_bytes() + m.value() as usize;
+                    haystack.clear();
+                    text.chars().for_each(|c| haystack.push(c));
+                    for i in 0..haystack.len() {
+                        for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                            dummy += j + v as usize;
                         }
                     }
                 }

--- a/bench/src/measure.rs
+++ b/bench/src/measure.rs
@@ -72,7 +72,7 @@ fn main() {
             let elapsed_sec = measure(TRIALS, || {
                 for text in texts {
                     haystack.clear();
-                    text.chars().for_each(|c| haystack.push(c));
+                    haystack.extend(text.chars());
                     for i in 0..haystack.len() {
                         for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
                             dummy += j + v as usize;
@@ -123,7 +123,7 @@ fn main() {
             let elapsed_sec = measure(TRIALS, || {
                 for text in texts {
                     haystack.clear();
-                    text.chars().for_each(|c| haystack.push(c));
+                    haystack.extend(text.chars());
                     for i in 0..haystack.len() {
                         for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
                             dummy += j + v as usize;

--- a/bench/src/measure.rs
+++ b/bench/src/measure.rs
@@ -119,13 +119,14 @@ fn main() {
         if let Some(texts) = texts.as_ref() {
             // Warmup
             let mut dummy = 0;
-            let mut searcher = trie.common_prefix_searcher();
+            let mut haystack = vec![];
             let elapsed_sec = measure(TRIALS, || {
                 for text in texts {
-                    searcher.update_haystack(text.chars());
-                    for i in 0..searcher.len_chars() {
-                        for m in searcher.search(i) {
-                            dummy += m.end_bytes() + m.value() as usize;
+                    haystack.clear();
+                    text.chars().for_each(|c| haystack.push(c));
+                    for i in 0..haystack.len() {
+                        for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                            dummy += j + v as usize;
                         }
                     }
                 }

--- a/bench/src/measure.rs
+++ b/bench/src/measure.rs
@@ -74,7 +74,7 @@ fn main() {
                     haystack.clear();
                     haystack.extend(text.chars());
                     for i in 0..haystack.len() {
-                        for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                        for (v, j) in trie.common_prefix_search(haystack[i..].iter().copied()) {
                             dummy += j + v as usize;
                         }
                     }
@@ -125,7 +125,7 @@ fn main() {
                     haystack.clear();
                     haystack.extend(text.chars());
                     for i in 0..haystack.len() {
-                        for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                        for (v, j) in trie.common_prefix_search(haystack[i..].iter().copied()) {
                             dummy += j + v as usize;
                         }
                     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -108,13 +108,13 @@ impl Builder {
         if self.suffixes.is_some() {
             Err(CrawdadError::setup("minimal_prefix must be disabled."))
         } else {
-            let Builder { nodes, mapper, .. } = self;
+            let Self { nodes, mapper, .. } = self;
             Ok(Trie { nodes, mapper })
         }
     }
 
     pub fn release_mptrie(self) -> Result<MpTrie> {
-        let Builder {
+        let Self {
             mapper,
             mut nodes,
             suffixes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,6 @@ pub mod mptrie;
 pub mod trie;
 mod utils;
 
-use core::ops::Range;
-
 pub(crate) const OFFSET_MASK: u32 = 0x7fff_ffff;
 pub(crate) const INVALID_IDX: u32 = 0xffff_ffff;
 pub(crate) const MAX_VALUE: u32 = OFFSET_MASK;
@@ -100,53 +98,6 @@ pub const END_MARKER: char = '\u{0}';
 
 pub use mptrie::MpTrie;
 pub use trie::Trie;
-
-/// Result of common prefix search.
-#[derive(Default, Clone)]
-pub struct Match {
-    value: u32,
-    range_chars: Range<usize>,
-    range_bytes: Range<usize>,
-}
-
-impl Match {
-    /// Value associated with the matched key.
-    #[inline(always)]
-    pub const fn value(&self) -> u32 {
-        self.value
-    }
-
-    /// Starting position of the match in characters.
-    #[inline(always)]
-    pub const fn start_chars(&self) -> usize {
-        self.range_chars.start
-    }
-
-    /// Ending position of the match in characters.
-    #[inline(always)]
-    pub const fn end_chars(&self) -> usize {
-        self.range_chars.end
-    }
-
-    /// Starting position of the match in bytes if characters are encoded in UTF-8.
-    #[inline(always)]
-    pub const fn start_bytes(&self) -> usize {
-        self.range_bytes.start
-    }
-
-    /// Ending position of the match in bytes if characters are encoded in UTF-8.
-    #[inline(always)]
-    pub const fn end_bytes(&self) -> usize {
-        self.range_bytes.end
-    }
-}
-
-/// Handler for a mapped character.
-#[derive(Default, Clone, Copy)]
-struct MappedChar {
-    c: Option<u32>,
-    end_bytes: usize,
-}
 
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 struct Node {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,23 +38,18 @@
 //! let keys = vec!["世界", "世界中", "国民"];
 //! let trie = Trie::from_keys(&keys).unwrap();
 //!
-//! let mut searcher = trie.common_prefix_searcher();
-//! searcher.update_haystack("国民が世界中にて".chars());
-//!
+//! let haystack: Vec<_> = "国民が世界中にて".chars().collect();
 //! let mut matches = vec![];
-//! for i in 0..searcher.len_chars() {
-//!     for m in searcher.search(i) {
-//!         matches.push((
-//!             m.value(),
-//!             m.start_chars()..m.end_chars(),
-//!             m.start_bytes()..m.end_bytes(),
-//!         ));
+//!
+//! for i in 0..haystack.len() {
+//!     for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+//!         matches.push((v, i..i + j));
 //!     }
 //! }
 //!
 //! assert_eq!(
 //!     matches,
-//!     vec![(2, 0..2, 0..6), (0, 3..5, 9..15), (1, 3..6, 9..18)]
+//!     vec![(2, 0..2), (0, 3..5), (1, 3..6)]
 //! );
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! ## Finding all occurrences of keys in an input text
 //!
 //! To search for all occurrences of registered keys in an input text,
-//! use [`Trie::common_prefix_searcher()`] for all starting positions in the text.
+//! use [`Trie::common_prefix_search()`] for all starting positions in the text.
 //!
 //! ```
 //! use crawdad::Trie;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,11 @@
 //! let keys = vec!["世界", "世界中", "国民"];
 //! let trie = Trie::from_keys(&keys).unwrap();
 //!
-//! let haystack: Vec<_> = "国民が世界中にて".chars().collect();
+//! let haystack: Vec<char> = "国民が世界中にて".chars().collect();
 //! let mut matches = vec![];
 //!
 //! for i in 0..haystack.len() {
-//!     for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+//!     for (v, j) in trie.common_prefix_search(haystack[i..].iter().copied()) {
 //!         matches.push((v, i..i + j));
 //!     }
 //! }

--- a/src/mptrie.rs
+++ b/src/mptrie.rs
@@ -236,7 +236,7 @@ impl MpTrie {
     /// Returns an iterator for common prefix search.
     ///
     /// The iterator reports all occurrences of keys starting from an input haystack, where
-    /// each occurrence consists of its associated value and ending positoin in characters.
+    /// an occurrence consists of its associated value and ending positoin in characters.
     ///
     /// # Examples
     ///

--- a/src/mptrie.rs
+++ b/src/mptrie.rs
@@ -8,7 +8,7 @@ use crate::END_CODE;
 
 use alloc::vec::Vec;
 
-use core::mem::size_of;
+use core::mem;
 
 /// A minimal-prefix trie form that is memory-efficient for long strings.
 pub struct MpTrie {
@@ -331,18 +331,18 @@ impl MpTrie {
     /// Returns the total amount of heap used by this automaton in bytes.
     pub fn heap_bytes(&self) -> usize {
         self.mapper.heap_bytes()
-            + self.nodes.len() * size_of::<Node>()
-            + self.tails.len() * size_of::<u8>()
+            + self.nodes.len() * mem::size_of::<Node>()
+            + self.tails.len() * mem::size_of::<u8>()
     }
 
     /// Returns the total amount of bytes to serialize the data structure.
     pub fn io_bytes(&self) -> usize {
         self.mapper.io_bytes()
             + self.nodes.len() * Node::io_bytes()
-            + size_of::<u32>()
-            + self.tails.len() * size_of::<u8>()
-            + size_of::<u32>()
-            + size_of::<u8>() * 2
+            + mem::size_of::<u32>()
+            + self.tails.len() * mem::size_of::<u8>()
+            + mem::size_of::<u32>()
+            + mem::size_of::<u8>() * 2
     }
 
     /// Returns the number of reserved elements.

--- a/src/mptrie.rs
+++ b/src/mptrie.rs
@@ -2,7 +2,7 @@
 use crate::builder::Builder;
 use crate::errors::Result;
 use crate::mapper::CodeMapper;
-use crate::{utils, MappedChar, Match, Node};
+use crate::{utils, Node};
 
 use crate::END_CODE;
 
@@ -248,51 +248,26 @@ impl MpTrie {
     /// let keys = vec!["世界", "世界中", "国民"];
     /// let trie = MpTrie::from_keys(&keys).unwrap();
     ///
-    /// let mut searcher = trie.common_prefix_searcher();
-    /// searcher.update_haystack("国民が世界中にて".chars());
-    ///
+    /// let haystack: Vec<_> = "国民が世界中にて".chars().collect();
     /// let mut matches = vec![];
-    /// for i in 0..searcher.len_chars() {
-    ///     for m in searcher.search(i) {
-    ///         matches.push((
-    ///             m.value(),
-    ///             m.start_chars()..m.end_chars(),
-    ///             m.start_bytes()..m.end_bytes(),
-    ///         ));
+    ///
+    /// for i in 0..haystack.len() {
+    ///     for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+    ///         matches.push((v, i..i + j));
     ///     }
     /// }
     ///
     /// assert_eq!(
     ///     matches,
-    ///     vec![(2, 0..2, 0..6), (0, 3..5, 9..15), (1, 3..6, 9..18)]
+    ///     vec![(2, 0..2), (0, 3..5), (1, 3..6)]
     /// );
     /// ```
-    pub const fn common_prefix_searcher(&self) -> CommonPrefixSearcher {
-        CommonPrefixSearcher {
+    pub const fn common_prefix_search<I>(&self, haystack: I) -> CommonPrefixSearchIter<I> {
+        CommonPrefixSearchIter {
+            haystack,
+            haystack_pos: 0,
             trie: self,
-            haystack: vec![],
-        }
-    }
-
-    /// Prepares a search haystack for common prefix search.
-    ///
-    /// # Arguments
-    ///
-    /// - `haystack`: Search haystack.
-    /// - `mapped`: Mapped haystack.
-    #[inline(always)]
-    fn map_haystack<I>(&self, haystack: I, mapped: &mut Vec<MappedChar>)
-    where
-        I: IntoIterator<Item = char>,
-    {
-        mapped.clear();
-        let mut end_bytes = 0;
-        for c in haystack {
-            end_bytes += c.len_utf8();
-            mapped.push(MappedChar {
-                c: self.mapper.get(c),
-                end_bytes,
-            });
+            node_idx: 0,
         }
     }
 
@@ -381,66 +356,27 @@ impl MpTrie {
     }
 }
 
-/// Common prefix searcher created by [`MpTrie::common_prefix_searcher`].
-pub struct CommonPrefixSearcher<'t> {
-    trie: &'t MpTrie,
-    haystack: Vec<MappedChar>,
-}
-
-impl CommonPrefixSearcher<'_> {
-    /// Sets a search haystack.
-    pub fn update_haystack<I>(&mut self, haystack: I)
-    where
-        I: IntoIterator<Item = char>,
-    {
-        self.trie.map_haystack(haystack, &mut self.haystack);
-    }
-
-    /// Gets the haystack length in characters.
-    pub fn len_chars(&self) -> usize {
-        self.haystack.len()
-    }
-
-    /// Creates an iterator to search for the haystack from the given position.
-    pub fn search(&self, start: usize) -> CommonPrefixSearchIter {
-        let start_chars = start;
-        let start_bytes = if start_chars == 0 {
-            0
-        } else {
-            self.haystack[start_chars - 1].end_bytes
-        };
-        CommonPrefixSearchIter {
-            haystack: &self.haystack,
-            haystack_pos: start_chars,
-            trie: self.trie,
-            node_idx: 0,
-            start_chars,
-            start_bytes,
-        }
-    }
-}
-
 /// Iterator for common prefix search.
-pub struct CommonPrefixSearchIter<'k, 't> {
-    haystack: &'k [MappedChar],
+pub struct CommonPrefixSearchIter<'t, I> {
+    haystack: I,
     haystack_pos: usize,
     trie: &'t MpTrie,
     node_idx: u32,
-    start_chars: usize,
-    start_bytes: usize,
 }
 
-impl Iterator for CommonPrefixSearchIter<'_, '_> {
-    type Item = Match;
+impl<I> Iterator for CommonPrefixSearchIter<'_, I>
+where
+    I: Iterator<Item = char>,
+{
+    type Item = (u32, usize);
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        while self.haystack_pos < self.haystack.len() {
-            let mc = self.haystack[self.haystack_pos];
-            if let Some(child_idx) = mc.c.and_then(|c| self.trie.get_child_idx(self.node_idx, c)) {
+        while let Some(c) = self.haystack.next() {
+            let mc = self.trie.mapper.get(c);
+            if let Some(child_idx) = mc.and_then(|c| self.trie.get_child_idx(self.node_idx, c)) {
                 self.node_idx = child_idx;
             } else {
-                self.haystack_pos = self.haystack.len();
                 return None;
             }
 
@@ -449,41 +385,15 @@ impl Iterator for CommonPrefixSearchIter<'_, '_> {
             if self.trie.is_leaf(self.node_idx) {
                 let tail_pos = usize::try_from(self.trie.get_value(self.node_idx)).unwrap();
                 let mut tail_iter = self.trie.tail_iter(tail_pos);
-
                 for tc in tail_iter.by_ref() {
-                    if self.haystack_pos == self.haystack.len() {
-                        return None;
-                    }
-                    let mc = self.haystack[self.haystack_pos];
-                    // TODO(vbkaisetsu): replace with is_some_with (nightly)
-                    // if !mc.c.is_some_with(|&c| c == tc) {
-                    if mc.c.filter(|&c| c == tc).is_none() {
-                        self.haystack_pos = self.haystack.len();
-                        return None;
-                    }
+                    let mc = self.trie.mapper.get(self.haystack.next()?);
+                    mc.filter(|&c| c == tc)?;
                     self.haystack_pos += 1;
                 }
-
-                let value = tail_iter.value();
-                let end_chars = self.haystack_pos;
-                let end_bytes = self.haystack[end_chars - 1].end_bytes;
-
-                self.haystack_pos = self.haystack.len();
-
-                return Some(Match {
-                    value,
-                    range_chars: self.start_chars..end_chars,
-                    range_bytes: self.start_bytes..end_bytes,
-                });
+                return Some((tail_iter.value(), self.haystack_pos));
             } else if self.trie.has_leaf(self.node_idx) {
                 let leaf_idx = self.trie.get_leaf_idx(self.node_idx);
-                let end_chars = self.haystack_pos;
-                let end_bytes = self.haystack[end_chars - 1].end_bytes;
-                return Some(Match {
-                    value: self.trie.get_value(leaf_idx),
-                    range_chars: self.start_chars..end_chars,
-                    range_bytes: self.start_bytes..end_bytes,
-                });
+                return Some((self.trie.get_value(leaf_idx), self.haystack_pos));
             }
         }
         None
@@ -546,24 +456,15 @@ mod tests {
         let keys = vec!["世界", "世界中", "世論調査", "統計調査"];
         let trie = MpTrie::from_keys(&keys).unwrap();
 
-        let mut searcher = trie.common_prefix_searcher();
-        searcher.update_haystack("世界中の統計世論調査".chars());
-
+        let haystack: Vec<_> = "世界中の統計世論調査".chars().collect();
         let mut matches = vec![];
-        for i in 0..searcher.len_chars() {
-            for m in searcher.search(i) {
-                matches.push((
-                    m.value(),
-                    m.start_chars()..m.end_chars(),
-                    m.start_bytes()..m.end_bytes(),
-                ));
+
+        for i in 0..haystack.len() {
+            for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                matches.push((v, i..i + j));
             }
         }
-
-        assert_eq!(
-            matches,
-            vec![(0, 0..2, 0..6), (1, 0..3, 0..9), (2, 6..10, 18..30)]
-        );
+        assert_eq!(matches, vec![(0, 0..2), (1, 0..3), (2, 6..10)]);
     }
 
     #[test]

--- a/src/mptrie.rs
+++ b/src/mptrie.rs
@@ -373,7 +373,7 @@ where
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(c) = self.haystack.next() {
+        for c in self.haystack.by_ref() {
             let mc = self.trie.mapper.get(c)?;
             self.node_idx = self.trie.get_child_idx(self.node_idx, mc)?;
             self.haystack_pos += 1;

--- a/src/mptrie.rs
+++ b/src/mptrie.rs
@@ -249,11 +249,11 @@ impl MpTrie {
     /// let keys = vec!["世界", "世界中", "国民"];
     /// let trie = MpTrie::from_keys(&keys).unwrap();
     ///
-    /// let haystack: Vec<_> = "国民が世界中にて".chars().collect();
+    /// let haystack: Vec<char> = "国民が世界中にて".chars().collect();
     /// let mut matches = vec![];
     ///
     /// for i in 0..haystack.len() {
-    ///     for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+    ///     for (v, j) in trie.common_prefix_search(haystack[i..].iter().copied()) {
     ///         matches.push((v, i..i + j));
     ///     }
     /// }
@@ -455,7 +455,7 @@ mod tests {
         let mut matches = vec![];
 
         for i in 0..haystack.len() {
-            for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+            for (v, j) in trie.common_prefix_search(haystack[i..].iter().copied()) {
                 matches.push((v, i..i + j));
             }
         }

--- a/src/mptrie.rs
+++ b/src/mptrie.rs
@@ -374,15 +374,9 @@ where
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(c) = self.haystack.next() {
-            let mc = self.trie.mapper.get(c);
-            if let Some(child_idx) = mc.and_then(|c| self.trie.get_child_idx(self.node_idx, c)) {
-                self.node_idx = child_idx;
-            } else {
-                return None;
-            }
-
+            let mc = self.trie.mapper.get(c)?;
+            self.node_idx = self.trie.get_child_idx(self.node_idx, mc)?;
             self.haystack_pos += 1;
-
             if self.trie.is_leaf(self.node_idx) {
                 let tail_pos = usize::try_from(self.trie.get_value(self.node_idx)).unwrap();
                 let mut tail_iter = self.trie.tail_iter(tail_pos);

--- a/src/mptrie.rs
+++ b/src/mptrie.rs
@@ -233,14 +233,15 @@ impl MpTrie {
         chars.next().is_none().then(|| tail_iter.value())
     }
 
-    /// Returns a common prefix searcher.
+    /// Returns an iterator for common prefix search.
     ///
-    /// The searcher finds all occurrences of keys starting from an input haystack, and
-    /// the occurrences are reported as a sequence of [`Match`](crate::Match).
+    /// The iterator reports all occurrences of keys starting from an input haystack, where
+    /// each occurrence consists of its associated value and ending positoin in characters.
     ///
     /// # Examples
     ///
-    /// You can find all occurrences  of keys in a haystack as follows.
+    /// You can find all occurrences of keys in a haystack by performing common prefix searches
+    /// at all starting positions.
     ///
     /// ```
     /// use crawdad::MpTrie;

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -318,7 +318,9 @@ where
             } else {
                 return None;
             }
+
             self.haystack_pos += 1;
+
             if self.trie.is_leaf(self.node_idx) {
                 return Some((self.trie.get_value(self.node_idx), self.haystack_pos));
             } else if self.trie.has_leaf(self.node_idx) {

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -205,11 +205,11 @@ impl Trie {
     /// let keys = vec!["世界", "世界中", "国民"];
     /// let trie = Trie::from_keys(&keys).unwrap();
     ///
-    /// let haystack: Vec<_> = "国民が世界中にて".chars().collect();
+    /// let haystack: Vec<char> = "国民が世界中にて".chars().collect();
     /// let mut matches = vec![];
     ///
     /// for i in 0..haystack.len() {
-    ///     for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+    ///     for (v, j) in trie.common_prefix_search(haystack[i..].iter().copied()) {
     ///         matches.push((v, i..i + j));
     ///     }
     /// }
@@ -358,7 +358,7 @@ mod tests {
         let mut matches = vec![];
 
         for i in 0..haystack.len() {
-            for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+            for (v, j) in trie.common_prefix_search(haystack[i..].iter().copied()) {
                 matches.push((v, i..i + j));
             }
         }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -192,7 +192,7 @@ impl Trie {
     /// Returns an iterator for common prefix search.
     ///
     /// The iterator reports all occurrences of keys starting from an input haystack, where
-    /// each occurrence consists of its associated value and ending positoin in characters.
+    /// an occurrence consists of its associated value and ending positoin in characters.
     ///
     /// # Examples
     ///

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -8,7 +8,7 @@ use crate::END_CODE;
 
 use alloc::vec::Vec;
 
-use core::mem::size_of;
+use core::mem;
 
 /// A standard trie form that often provides the fastest queries.
 pub struct Trie {
@@ -276,12 +276,12 @@ impl Trie {
 
     /// Returns the total amount of heap used by this automaton in bytes.
     pub fn heap_bytes(&self) -> usize {
-        self.mapper.heap_bytes() + self.nodes.len() * size_of::<Node>()
+        self.mapper.heap_bytes() + self.nodes.len() * mem::size_of::<Node>()
     }
 
     /// Returns the total amount of bytes to serialize the data structure.
     pub fn io_bytes(&self) -> usize {
-        self.mapper.io_bytes() + self.nodes.len() * Node::io_bytes() + size_of::<u32>()
+        self.mapper.io_bytes() + self.nodes.len() * Node::io_bytes() + mem::size_of::<u32>()
     }
 
     /// Returns the number of reserved elements.

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -2,7 +2,7 @@
 use crate::builder::Builder;
 use crate::errors::Result;
 use crate::mapper::CodeMapper;
-use crate::{MappedChar, Match, Node};
+use crate::Node;
 
 use crate::END_CODE;
 
@@ -204,51 +204,26 @@ impl Trie {
     /// let keys = vec!["世界", "世界中", "国民"];
     /// let trie = Trie::from_keys(&keys).unwrap();
     ///
-    /// let mut searcher = trie.common_prefix_searcher();
-    /// searcher.update_haystack("国民が世界中にて".chars());
-    ///
+    /// let haystack: Vec<_> = "国民が世界中にて".chars().collect();
     /// let mut matches = vec![];
-    /// for i in 0..searcher.len_chars() {
-    ///     for m in searcher.search(i) {
-    ///         matches.push((
-    ///             m.value(),
-    ///             m.start_chars()..m.end_chars(),
-    ///             m.start_bytes()..m.end_bytes(),
-    ///         ));
+    ///
+    /// for i in 0..haystack.len() {
+    ///     for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+    ///         matches.push((v, i..i + j));
     ///     }
     /// }
     ///
     /// assert_eq!(
     ///     matches,
-    ///     vec![(2, 0..2, 0..6), (0, 3..5, 9..15), (1, 3..6, 9..18)]
+    ///     vec![(2, 0..2), (0, 3..5), (1, 3..6)]
     /// );
     /// ```
-    pub const fn common_prefix_searcher(&self) -> CommonPrefixSearcher {
-        CommonPrefixSearcher {
+    pub const fn common_prefix_search<I>(&self, haystack: I) -> CommonPrefixSearchIter<I> {
+        CommonPrefixSearchIter {
+            haystack,
+            haystack_pos: 0,
             trie: self,
-            haystack: vec![],
-        }
-    }
-
-    /// Prepares a search haystack for common prefix search.
-    ///
-    /// # Arguments
-    ///
-    /// - `haystack`: Search haystack.
-    /// - `mapped`: Mapped haystack.
-    #[inline(always)]
-    fn map_haystack<I>(&self, haystack: I, mapped: &mut Vec<MappedChar>)
-    where
-        I: IntoIterator<Item = char>,
-    {
-        mapped.clear();
-        let mut end_bytes = 0;
-        for c in haystack {
-            end_bytes += c.len_utf8();
-            mapped.push(MappedChar {
-                c: self.mapper.get(c),
-                end_bytes,
-            });
+            node_idx: 0,
         }
     }
 
@@ -320,89 +295,35 @@ impl Trie {
     }
 }
 
-/// Common prefix searcher created by [`Trie::common_prefix_searcher`].
-pub struct CommonPrefixSearcher<'t> {
-    trie: &'t Trie,
-    haystack: Vec<MappedChar>,
-}
-
-impl CommonPrefixSearcher<'_> {
-    /// Sets a search haystack.
-    pub fn update_haystack<I>(&mut self, haystack: I)
-    where
-        I: IntoIterator<Item = char>,
-    {
-        self.trie.map_haystack(haystack, &mut self.haystack);
-    }
-
-    /// Gets the haystack length in characters.
-    pub fn len_chars(&self) -> usize {
-        self.haystack.len()
-    }
-
-    /// Creates an iterator to search for the haystack from the given position.
-    pub fn search(&self, start: usize) -> CommonPrefixSearchIter {
-        let start_chars = start;
-        let start_bytes = if start_chars == 0 {
-            0
-        } else {
-            self.haystack[start_chars - 1].end_bytes
-        };
-        CommonPrefixSearchIter {
-            haystack: &self.haystack,
-            haystack_pos: start_chars,
-            trie: self.trie,
-            node_idx: 0,
-            start_chars,
-            start_bytes,
-        }
-    }
-}
-
 /// Iterator for common prefix search.
-pub struct CommonPrefixSearchIter<'k, 't> {
-    haystack: &'k [MappedChar],
+pub struct CommonPrefixSearchIter<'t, I> {
+    haystack: I,
     haystack_pos: usize,
     trie: &'t Trie,
     node_idx: u32,
-    start_chars: usize,
-    start_bytes: usize,
 }
 
-impl Iterator for CommonPrefixSearchIter<'_, '_> {
-    type Item = Match;
+impl<I> Iterator for CommonPrefixSearchIter<'_, I>
+where
+    I: Iterator<Item = char>,
+{
+    type Item = (u32, usize);
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        while self.haystack_pos < self.haystack.len() {
-            let mc = self.haystack[self.haystack_pos];
-            if let Some(child_idx) = mc.c.and_then(|c| self.trie.get_child_idx(self.node_idx, c)) {
+        while let Some(c) = self.haystack.next() {
+            let mc = self.trie.mapper.get(c);
+            if let Some(child_idx) = mc.and_then(|c| self.trie.get_child_idx(self.node_idx, c)) {
                 self.node_idx = child_idx;
             } else {
-                self.haystack_pos = self.haystack.len();
                 return None;
             }
-
             self.haystack_pos += 1;
-
             if self.trie.is_leaf(self.node_idx) {
-                let end_chars = self.haystack_pos;
-                let end_bytes = self.haystack[end_chars - 1].end_bytes;
-                self.haystack_pos = self.haystack.len();
-                return Some(Match {
-                    value: self.trie.get_value(self.node_idx),
-                    range_chars: self.start_chars..end_chars,
-                    range_bytes: self.start_bytes..end_bytes,
-                });
+                return Some((self.trie.get_value(self.node_idx), self.haystack_pos));
             } else if self.trie.has_leaf(self.node_idx) {
                 let leaf_idx = self.trie.get_leaf_idx(self.node_idx);
-                let end_chars = self.haystack_pos;
-                let end_bytes = self.haystack[end_chars - 1].end_bytes;
-                return Some(Match {
-                    value: self.trie.get_value(leaf_idx),
-                    range_chars: self.start_chars..end_chars,
-                    range_bytes: self.start_bytes..end_bytes,
-                });
+                return Some((self.trie.get_value(leaf_idx), self.haystack_pos));
             }
         }
         None
@@ -436,24 +357,15 @@ mod tests {
         let keys = vec!["世界", "世界中", "世論調査", "統計調査"];
         let trie = Trie::from_keys(&keys).unwrap();
 
-        let mut searcher = trie.common_prefix_searcher();
-        searcher.update_haystack("世界中の統計世論調査".chars());
-
+        let haystack: Vec<_> = "世界中の統計世論調査".chars().collect();
         let mut matches = vec![];
-        for i in 0..searcher.len_chars() {
-            for m in searcher.search(i) {
-                matches.push((
-                    m.value(),
-                    m.start_chars()..m.end_chars(),
-                    m.start_bytes()..m.end_bytes(),
-                ));
+
+        for i in 0..haystack.len() {
+            for (v, j) in trie.common_prefix_search(haystack[i..].iter().cloned()) {
+                matches.push((v, i..i + j));
             }
         }
-
-        assert_eq!(
-            matches,
-            vec![(0, 0..2, 0..6), (1, 0..3, 0..9), (2, 6..10, 18..30)]
-        );
+        assert_eq!(matches, vec![(0, 0..2), (1, 0..3), (2, 6..10)]);
     }
 
     #[test]

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -312,7 +312,7 @@ where
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(c) = self.haystack.next() {
+        for c in self.haystack.by_ref() {
             let mc = self.trie.mapper.get(c)?;
             self.node_idx = self.trie.get_child_idx(self.node_idx, mc)?;
             self.haystack_pos += 1;

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -313,15 +313,9 @@ where
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(c) = self.haystack.next() {
-            let mc = self.trie.mapper.get(c);
-            if let Some(child_idx) = mc.and_then(|c| self.trie.get_child_idx(self.node_idx, c)) {
-                self.node_idx = child_idx;
-            } else {
-                return None;
-            }
-
+            let mc = self.trie.mapper.get(c)?;
+            self.node_idx = self.trie.get_child_idx(self.node_idx, mc)?;
             self.haystack_pos += 1;
-
             if self.trie.is_leaf(self.node_idx) {
                 return Some((self.trie.get_value(self.node_idx), self.haystack_pos));
             } else if self.trie.has_leaf(self.node_idx) {

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -189,14 +189,15 @@ impl Trie {
         }
     }
 
-    /// Returns a common prefix searcher.
+    /// Returns an iterator for common prefix search.
     ///
-    /// The searcher finds all occurrences of keys starting from an input haystack, and
-    /// the occurrences are reported as a sequence of [`Match`](crate::Match).
+    /// The iterator reports all occurrences of keys starting from an input haystack, where
+    /// each occurrence consists of its associated value and ending positoin in characters.
     ///
     /// # Examples
     ///
-    /// You can find all occurrences of keys in a haystack as follows.
+    /// You can find all occurrences of keys in a haystack by performing common prefix searches
+    /// at all starting positions.
     ///
     /// ```
     /// use crawdad::Trie;


### PR DESCRIPTION
This PR simplifies the implementation of common prefix search and avoids storing mapped characters in an auxiliary data structure. With this modification, the search speed was improved as follows.

```
unidic/cps/crawdad/trie time:   [6.9536 ms 6.9676 ms 6.9839 ms]
                        change: [-14.553% -13.982% -13.439%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
unidic/cps/crawdad/mptrie
                        time:   [8.1081 ms 8.1424 ms 8.1795 ms]
                        change: [-18.109% -17.562% -16.983%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```

## Discussion

This modification contains the following trade off.

 - Pros.
   - Make the API simpler.
   - Remove the auxiliary data structure to store mapped characters.
 - Cons.
   - Map the same characters in a haystack repeatedly.
   - Omit byte positions from matched results.

The experimental results indicate that storing and accessing mapped characters in an array is more costly than mapping characters repeatedly. The new simpler API would be easier to use, since it is not necessary to create an instance to store characters. Byte positions are not a necessary result for all users, so there would be no need to provide them in this library.