### PR TITLE
Support unsorted patterns

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -524,7 +524,7 @@ fn make_prefix_free(records: &mut [Record]) -> Result<()> {
                     "records must not contain duplicated keys.",
                 ));
             }
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
     Ok(())

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -84,6 +84,8 @@ impl Builder {
             })
             .collect();
 
+        self.records.sort_unstable_by(|a, b| a.key.cmp(&b.key));
+
         for &Record { key: _, value } in &self.records {
             if MAX_VALUE < value {
                 return Err(CrawdadError::scale("input value", MAX_VALUE));
@@ -522,9 +524,7 @@ fn make_prefix_free(records: &mut [Record]) -> Result<()> {
                     "records must not contain duplicated keys.",
                 ));
             }
-            Ordering::Greater => {
-                return Err(CrawdadError::input("records must be sorted."));
-            }
+            _ => unreachable!()
         }
     }
     Ok(())

--- a/src/mptrie.rs
+++ b/src/mptrie.rs
@@ -36,7 +36,6 @@ impl MpTrie {
     /// - `keys` is empty,
     /// - `keys` contains empty strings,
     /// - `keys` contains duplicate keys,
-    /// - `keys` is not sorted,
     /// - the scale of `keys` exceeds the expected one, or
     /// - the scale of the resulting trie exceeds the expected one.
     ///
@@ -74,7 +73,6 @@ impl MpTrie {
     /// - `records` is empty,
     /// - `records` contains empty strings,
     /// - `records` contains duplicate keys,
-    /// - keys in `records` are not sorted,
     /// - the scale of `keys` exceeds the expected one, or
     /// - the scale of the resulting trie exceeds the expected one.
     ///
@@ -501,8 +499,8 @@ mod tests {
 
     #[test]
     fn test_unsorted_keys() {
-        assert!(MpTrie::from_keys(["BB", "AA"]).is_err());
-        assert!(MpTrie::from_keys(["AAA", "AA"]).is_err());
+        assert!(MpTrie::from_keys(["BB", "AA"]).is_ok());
+        assert!(MpTrie::from_keys(["AAA", "AA"]).is_ok());
     }
 
     #[test]

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -33,7 +33,6 @@ impl Trie {
     /// - `keys` is empty,
     /// - `keys` contains empty strings,
     /// - `keys` contains duplicate keys,
-    /// - `keys` is not sorted,
     /// - the scale of `keys` exceeds the expected one, or
     /// - the scale of the resulting trie exceeds the expected one.
     ///
@@ -68,7 +67,6 @@ impl Trie {
     /// - `records` is empty,
     /// - `records` contains empty strings,
     /// - `records` contains duplicate keys,
-    /// - keys in `records` are not sorted,
     /// - the scale of `keys` exceeds the expected one, or
     /// - the scale of the resulting trie exceeds the expected one.
     ///
@@ -401,8 +399,8 @@ mod tests {
 
     #[test]
     fn test_unsorted_keys() {
-        assert!(Trie::from_keys(["BB", "AA"]).is_err());
-        assert!(Trie::from_keys(["AAA", "AA"]).is_err());
+        assert!(Trie::from_keys(["BB", "AA"]).is_ok());
+        assert!(Trie::from_keys(["AAA", "AA"]).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Solves #30 

This branch automatically sorts patterns before constructing a trie.